### PR TITLE
Fix test id detection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
+      "preLaunchTask": "npm: build",
       "outFiles": [
         "${workspaceFolder}/out"
       ]

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -53,7 +53,8 @@ export class TestExplorerStatusBarController implements TestController {
         this.setStatusBarItemText('started');
         this.resetTestState(testAdapterState);
       } else if (testRunEvent.type === 'test') {
-        this.setTestState(testAdapterState, testRunEvent.test as String, testRunEvent.state);
+        const testId = (typeof testRunEvent.test === 'string') ? testRunEvent.test : testRunEvent.test.id;
+        this.setTestState(testAdapterState, testId, testRunEvent.state);
         this.getTestStates(testAdapterState);
         this.setStatusBarItemText('running');
       } else if (testRunEvent.type === 'finished') {


### PR DESCRIPTION
Adapters can set property `test` of `TestRunEvent` to id or a whole `TestInfo`. For example, [Catch2 and Google Test Explorer](https://marketplace.visualstudio.com/items?itemName=matepek.vscode-catch2-test-adapter) uses `TestInfo`. Because of this, the number of completed tests in the status bar is always 0 for this test adapter. This PR checks the type of the `test` property similar to how Test Explorer UI is doing it.