### PR TITLE
Add error background color to the Test Explorer Status Bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- When the test run fails, the status bar item background will now use the error background theme color. ([#13](https://github.com/connorshea/vscode-test-explorer-status-bar/pull/13))
+
+### Changed
+- Updated dependencies.
 
 ## [1.1.2] - 2019-06-18
 ### Fixed

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -157,16 +157,24 @@ export class TestExplorerStatusBarController implements TestController {
     });
     const totalPassed = this.countTests(s => s.passedTests);
     const totalFailed = this.countTests(s => s.failedTests);
+    // Reset the background color, to prevent the error state from persisting unnecessarily.
+    this.statusBarItem.backgroundColor = undefined;
     switch (status) {
       case 'running':
         let percentageComplete = (((totalPassed + totalFailed) / totalTests) * 100).toFixed(1);
         failedTestString = '';
-        if (totalFailed > 0) { failedTestString = ` | $(x) ${totalFailed}` }
+        if (totalFailed > 0) {
+          failedTestString = ` | $(x) ${totalFailed}`;
+          this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+        }
         statusBarText += `${totalTests} tests | ${percentageComplete}% ($(check) ${totalPassed}${failedTestString})`;
         break;
       case 'finished':
         failedTestString = '';
-        if (totalFailed > 0) { failedTestString = ` | $(x) ${totalFailed}` }
+        if (totalFailed > 0) {
+          failedTestString = ` | $(x) ${totalFailed}`;
+          this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+        }
         statusBarText += `${totalTests} tests ($(check) ${totalPassed}${failedTestString})`;
         break;
       case 'started':


### PR DESCRIPTION
Now when the test run fails, the status bar item background turns red.

Resolves #8.